### PR TITLE
int() behavior for negative arguments

### DIFF
--- a/01_basics/03_basics.ipynb
+++ b/01_basics/03_basics.ipynb
@@ -1382,7 +1382,7 @@
     }
    },
    "source": [
-    "The `int()` function will truncate decimal numbers down."
+    "The `int()` function will truncate decimal numbers towards zero (down for positive numbers, but up for negative numbers)."
    ]
   },
   {
@@ -1410,7 +1410,7 @@
    },
    "outputs": [],
    "source": [
-    "int(41.95)"
+    "int(-41.95)"
    ]
   },
   {


### PR DESCRIPTION
I changed the description of int()'s behavior and also provided an example.